### PR TITLE
Test incoming log files for float compatibility. On fail, use str

### DIFF
--- a/nnaps/mesa/compress_mesa.py
+++ b/nnaps/mesa/compress_mesa.py
@@ -51,6 +51,10 @@ def read_mesa_output(filename=None, only_first=False):
             if all([iline == str(irange) for iline, irange in zip(line, range(1, len(line) + 1))]):
                 # -- wrap up previous model
                 if len(models):
+                    try:
+                        model = np.array(models[-1], float).T
+                    except:
+                        model = np.array(models[-1], str).T
                     model = np.array(models[-1], float).T
                     models[-1] = np.rec.fromarrays(model, names=header)
                     if only_first: break


### PR DESCRIPTION
I'm unsure of how the rest of the code is structured, or if the layout of the log files changed at some point, so I added 3 lines of code to sidestep the issue. On my machine, this seems to produce h5 files just fine.

Possible fix for issue #1 